### PR TITLE
[New Plugin] Usepe Logger

### DIFF
--- a/plugins/usepe_logger.py
+++ b/plugins/usepe_logger.py
@@ -1,0 +1,56 @@
+""" To-Do """
+# Import the global bluesky objects. Uncomment the ones you need
+from bluesky import core, traf  #, stack, settings, navdb, sim, scr, tools
+from bluesky.tools import datalog
+
+logger = None
+
+confheader = \
+    'CONFLICTS LOG\n' + \
+    'Beginning and end of all conflicts\n\n' + \
+    'Simulation Time [s], UAS1, UAS2, Start/End'
+
+### Initialisation function of your plugin. Do not change the name of this
+### function, as it is the way BlueSky recognises this file as a plugin.
+def init_plugin():
+    ''' Plugin initialisation function. '''
+    # Instantiate the UsepeLogger entity
+    usepelogger = UsepeLogger()
+
+    global logger
+    logger = datalog.crelog('USEPECONFLOG', None, confheader)
+
+    # Configuration parameters
+    config = {
+        'plugin_name':     'USEPELOGGER',
+        'plugin_type':     'sim',
+        'update_interval': 5.0,
+        'update': usepelogger.update
+        }
+
+    # init_plugin() should always return a configuration dict.
+    return config
+
+class UsepeLogger(core.Entity):
+    ''' To-Do '''
+
+    def __init__(self):
+        super().__init__()
+        
+        self.prevconf = list()
+
+    def update(self):
+        currentconf = list()
+        for pair in traf.cd.confpairs_unique:
+            uas1, uas2 = pair
+            sortedpair = [uas1, uas2]
+            sortedpair.sort()
+            currentconf.append(sortedpair)
+            if sortedpair not in self.prevconf:
+                logger.log(f' {sortedpair[0]}, {sortedpair[1]}, start')
+        
+        for pair in self.prevconf:
+            if pair not in currentconf:
+                logger.log(f' {pair[0]}, {pair[1]}, end')
+        
+        self.prevconf = currentconf


### PR DESCRIPTION
This plugin will manage all the data loggers we will need.

To start the plugin: `PLUGIN LOAD USEPELOGGER`
Each data logger must be switched on to function: `<name-of-logger> ON`

Currently there is a conflicts logger, which marks the beginning and end of all conflicts.

I am working on the implementation of logging loss of separation and accidents as well.
This will also allow us to measure the overall number of conflicts, amount of time spent in conflict, and how often conflicts are resolved.
All of this should fall under the KPA Safety.

I am looking at the other KPAs as well, Capacity and Operational Efficiency.

Any suggestions for further logging are welcome.
While there are no conflicts with merging this, I will leave the pull request until Friday to allow additional comments from other teams.