### PR TITLE
Add Loss of Separation to usepe_logger.py

### DIFF
--- a/plugins/usepe_logger.py
+++ b/plugins/usepe_logger.py
@@ -1,9 +1,9 @@
-""" This plugin manages all the datalogs for the USEPE project. """
+""" This plugin manages all the data loggers for the USEPE project. """
 # Import the global bluesky objects. Uncomment the ones you need
 from bluesky import core, traf  #, stack, settings, navdb, sim, scr, tools
 from bluesky.tools import datalog
 
-# Datalog for all conflicts
+# The data loggers
 conflog = None
 loslog = None
 
@@ -25,6 +25,7 @@ def init_plugin():
     # Instantiate the UsepeLogger entity
     usepelogger = UsepeLogger()
 
+    # Create the loggers
     global conflog
     global loslog
     conflog = datalog.crelog('USEPECONFLOG', None, confheader)
@@ -42,7 +43,7 @@ def init_plugin():
     return config
 
 class UsepeLogger(core.Entity):
-    ''' Provides the needed funcionality for each log '''
+    ''' Provides the needed funcionality for each log. '''
 
     def __init__(self):
         super().__init__()
@@ -53,6 +54,7 @@ class UsepeLogger(core.Entity):
         self.prevlos = list()
 
     def update(self):
+        ''' Periodic function calling each logger function. '''
         self.los_logger()
 
         currentconf = list()
@@ -76,6 +78,7 @@ class UsepeLogger(core.Entity):
         self.prevconf = currentconf
     
     def los_logger(self):
+        ''' Sorts current LoS and logs new and ended events. '''
         currentlos = list()
 
         # Go through all loss of separation pairs and sort the IDs for easier matching
@@ -88,19 +91,6 @@ class UsepeLogger(core.Entity):
         # Log start and end of LoS
         loslog.log(startlos, 'start')
         loslog.log(endlos, 'end')
-
-        # for pair in traf.cd.lospairs_unique:
-        #     uas1, uas2 = pair
-        #     sortedpair = [uas1, uas2]
-        #     sortedpair.sort()
-        #     currentlos.append(sortedpair)
-        #     if sortedpair not in self.prevlos:
-        #         loslog.log(f' {sortedpair[0]}, {sortedpair[1]}, start')
-
-        # # Log all ended loss of separation
-        # for pair in self.prevlos:
-        #     if pair not in currentlos:
-        #         loslog.log(f' {pair[0]}, {pair[1]}, end')
         
         # Store the new loss of separation environment
         self.prevlos = currentlos

--- a/plugins/usepe_logger.py
+++ b/plugins/usepe_logger.py
@@ -79,8 +79,7 @@ class UsepeLogger(core.Entity):
         currentlos = list()
 
         # Go through all loss of separation pairs and sort the IDs for easier matching
-        currentlos = [list(pair) for pair in traf.cd.lospairs_unique]
-        for pair in currentlos: pair.sort()
+        currentlos = [sorted(pair) for pair in traf.cd.lospairs_unique]
         
         # Create lists of all new and ended LoS
         startlos = [currpair for currpair in currentlos if currpair not in self.prevlos]

--- a/plugins/usepe_logger.py
+++ b/plugins/usepe_logger.py
@@ -1,7 +1,10 @@
 """ This plugin manages all the data loggers for the USEPE project. """
 # Import the global bluesky objects. Uncomment the ones you need
-from bluesky import core, traf  #, stack, settings, navdb, sim, scr, tools
+from bluesky import core, traf, stack #, settings, navdb, sim, scr, tools
 from bluesky.tools import datalog
+
+# List of the names of all the data loggers
+loggers = ['USEPECONFLOG', 'USEPELOSLOG']
 
 # The data loggers
 conflog = None
@@ -39,8 +42,17 @@ def init_plugin():
         'update': usepelogger.update
         }
 
+    stackfunctions = {
+        'USEPELOGGER': [
+            'USEPELOGGER LIST/ON',
+            'txt',
+            usepelogger.usepelogger,
+            'List/enable all the available data loggers'
+        ]
+    }
+
     # init_plugin() should always return a configuration dict.
-    return config
+    return config, stackfunctions
 
 class UsepeLogger(core.Entity):
     ''' Provides the needed funcionality for each log. '''
@@ -93,3 +105,17 @@ class UsepeLogger(core.Entity):
         
         # Store the new loss of separation environment
         self.prevlos = currentlos
+
+    def usepelogger(self, cmd):
+        ''' USEPELOGGER command for the plugin.
+            Options:
+            LIST: List all the available data loggers for the project
+            ON: Enable all the data loggers '''
+        if cmd == 'LIST':
+            return True, f'Available data loggers: {str.join(", ", loggers)}'
+        elif cmd == 'ON':
+            for x in range(len(loggers)):
+                stack.stack(f'{loggers[x]} ON')
+            return True, f'All data loggers for USEPE enabled.'
+        else:
+            return False, f'Available commands are: LIST, ON'

--- a/plugins/usepe_logger.py
+++ b/plugins/usepe_logger.py
@@ -47,10 +47,9 @@ class UsepeLogger(core.Entity):
     def __init__(self):
         super().__init__()
         
-        # This list stores the conflicts from the previous step, 
-        # ensuring each conflict is logged only once and that we know when they have ended.
+        # These lists stores the events from the previous step, 
+        # ensuring each event is logged only once and that we know when they have ended.
         self.prevconf = list()
-
         self.prevlos = list()
 
     def update(self):
@@ -80,19 +79,29 @@ class UsepeLogger(core.Entity):
         currentlos = list()
 
         # Go through all loss of separation pairs and sort the IDs for easier matching
-        # Log any new loss of separation
-        for pair in traf.cd.lospairs_unique:
-            uas1, uas2 = pair
-            sortedpair = [uas1, uas2]
-            sortedpair.sort()
-            currentlos.append(sortedpair)
-            if sortedpair not in self.prevlos:
-                loslog.log(f' {sortedpair[0]}, {sortedpair[1]}, start')
+        currentlos = [list(pair) for pair in traf.cd.lospairs_unique]
+        for pair in currentlos: pair.sort()
+        
+        # Create lists of all new and ended LoS
+        startlos = [currpair for currpair in currentlos if currpair not in self.prevlos]
+        endlos = [prevpair for prevpair in self.prevlos if prevpair not in currentlos]
 
-        # Log all ended loss of separation
-        for pair in self.prevlos:
-            if pair not in currentlos:
-                loslog.log(f' {pair[0]}, {pair[1]}, end')
+        # Log start and end of LoS
+        loslog.log(startlos, 'start')
+        loslog.log(endlos, 'end')
+
+        # for pair in traf.cd.lospairs_unique:
+        #     uas1, uas2 = pair
+        #     sortedpair = [uas1, uas2]
+        #     sortedpair.sort()
+        #     currentlos.append(sortedpair)
+        #     if sortedpair not in self.prevlos:
+        #         loslog.log(f' {sortedpair[0]}, {sortedpair[1]}, start')
+
+        # # Log all ended loss of separation
+        # for pair in self.prevlos:
+        #     if pair not in currentlos:
+        #         loslog.log(f' {pair[0]}, {pair[1]}, end')
         
         # Store the new loss of separation environment
         self.prevlos = currentlos

--- a/plugins/usepe_logger.py
+++ b/plugins/usepe_logger.py
@@ -55,24 +55,23 @@ class UsepeLogger(core.Entity):
 
     def update(self):
         ''' Periodic function calling each logger function. '''
+        self.conf_logger()
         self.los_logger()
 
+    def conf_logger(self):
+        ''' Sorts current conflicts and logs new and ended events. '''
         currentconf = list()
         
         # Go through all conflict pairs and sort the IDs for easier matching
-        # Log any new conflict
-        for pair in traf.cd.confpairs_unique:
-            uas1, uas2 = pair
-            sortedpair = [uas1, uas2]
-            sortedpair.sort()
-            currentconf.append(sortedpair)
-            if sortedpair not in self.prevconf:
-                conflog.log(f' {sortedpair[0]}, {sortedpair[1]}, start')
-        
-        # Log all ended conflicts
-        for pair in self.prevconf:
-            if pair not in currentconf:
-                conflog.log(f' {pair[0]}, {pair[1]}, end')
+        currentconf = [sorted(pair) for pair in traf.cd.confpairs_unique]
+
+        # Create lists of all new and ended conflicts
+        startconf = [currpair for currpair in currentconf if currpair not in self.prevconf]
+        endconf = [prevpair for prevpair in self.prevconf if prevpair not in currentconf]
+
+        # Log start and end of conflicts
+        conflog.log(startconf, 'start')
+        conflog.log(endconf, 'end')
 
         # Store the new conflict environment
         self.prevconf = currentconf


### PR DESCRIPTION
The log for Loss of Separation is separate from the one for Conflicts, but is structured in the same way.

Considering the analysis that is to come, are there any objections to logging each parameter separately? Would you rather have them in one log file with an additional field denoting the type of event (conflict, LoS, etc...)?

@dulli I have used list comprehension for this variant, including the two lists `startlos` and `endlos`. Is this how you envisioned it? I couldn't find a way to sort the pairs of `currentlos` without a one-line for loop, as `sort()` works directly on the list rather than return a sorted list.

Depending on your comments I may modify the code for logging conflicts as well, before merge.
