### PR TITLE
Add Closest Point of Approach to usepe_logger.py

### DIFF
--- a/plugins/usepe_logger.py
+++ b/plugins/usepe_logger.py
@@ -10,6 +10,7 @@ loggers = ['USEPECONFLOG', 'USEPELOSLOG', 'USEPECPALOG']
 conflog = None
 loslog = None
 cpalog = None
+updateInterval = 1.0
 
 # Parameters used when logging
 confheader = \
@@ -46,7 +47,7 @@ def init_plugin():
     config = {
         'plugin_name':     'USEPELOGGER',
         'plugin_type':     'sim',
-        'update_interval': 1.0,
+        'update_interval': updateInterval,
         'update': usepelogger.update
         }
 
@@ -122,7 +123,7 @@ class UsepeLogger(core.Entity):
         # For the best estimate, CPA is logged just after it happens (when tcpa turns negative)
         for x in range(len(traf.cd.confpairs)):
             pair = sorted(traf.cd.confpairs[x])
-            if (-1 < traf.cd.tcpa[x] <= 0) and (pair not in loggedpair):
+            if (-1 * updateInterval < traf.cd.tcpa[x] <= 0) and (pair not in loggedpair):
                 cpalog.log(pair[0], pair[1], traf.cd.dcpa[x])
                 loggedpair.append(pair)
 


### PR DESCRIPTION
This log will allow us to analyse accidents (near misses, mid-air collisions...).
As of now, it logs all CPA regardless of distance. This means post-process analysis is needed to find actual accidents.

Would it be preferable to test for this within the plugin instead and only log accidents?
It could compare with a stored distance defining what constitutes an accident (even differentiating between near misses and collisions if wanted).

The log looks like this:

```
# CLOSEST POINT OF APPROACH LOG
# Shortest distance between 2 UAS in conflict
# 
# Simulation Time [s], UAS1, UAS2, Distance [m]
# simt
248.00000000,UAS2,UAS3,243.73551380
306.00000000,D227,UAS2,112.02969928
332.00000000,D630,UAS2,74.78448547
350.00000000,D269,D887,84.66928970
359.00000000,D338,UAS1,63.80038288
363.00000000,D418,D749,108.03603989
369.00000000,D630,UAS2,194.99914309
390.00000000,D227,UAS4,7.42090907
```