### PR TITLE
[city_model]

### DIFF
--- a/usepe/city_model/main.py
+++ b/usepe/city_model/main.py
@@ -38,7 +38,7 @@ if __name__ == '__main__':
     Change the config_path to read the desired file
     """
     # CONFIG
-    config_path = "C:/workspace3/bluesky_USEPE/nommon/city_model/settings.cfg"
+    config_path = "C:/workspace3/bluesky-USEPE-github-2/usepe/city_model/settings.cfg"
     config = configparser.ConfigParser()
     config.read( config_path )
 

--- a/usepe/city_model/settings.cfg
+++ b/usepe/city_model/settings.cfg
@@ -1,47 +1,47 @@
 [City]
 mode = rectangle
-hannover_lat = 52.376
-hannover_lon = 9.76
-zone_size = 1000
-hannover_lat_min = 52.35
-hannover_lat_max = 52.4
-hannover_lon_min = 9.72
-hannover_lon_max = 9.78
-import = True
-imported_graph_path = .\data\hannover.graphml
+# hannover_lat = 52.376
+# hannover_lon = 9.76
+# zone_size = 1000
+hannover_lat_min = 52.36
+hannover_lat_max = 52.40
+hannover_lon_min = 9.71
+hannover_lon_max = 9.76
+import = False
+imported_graph_path = ./data/last_mile_delivery_test.graphml
 
 [Layers]
 number_of_layers = 9
 layer_width = 25
 
-[Corridors]
-corridors = 1 2 3 4 5
-altitude = 250
-delta_z = 25
-speed = 100
-acceleration_length = 50
-file_path_corridors = ./data/corridor_coordinates_nommon.csv
-#file_path_corridors = ./data/usepe-hannover-corridors.geojson
-
-[Segments]
-import = True
-path = .\data\my_segments.npy
-
 [BuildingData]
-lat_min = 52.35
-lat_max = 52.4
-lon_min = 9.72
-lon_max = 9.78
+lat_min = 52.36
+lat_max = 52.40
+lon_min = 9.71
+lon_max = 9.76
 divisions = 8
 directory_hannover = C:\Users\jbueno\Desktop\Stadtmodell_Hannover_CityGML_LoD1\LoD1_Graph
 
 [Options]
 one_way = False
-simplify = False
-simplification_distance = 12
+simplify = True
+simplification_distance = 0
+simplification_error = 2
 
 [Outputs]
-graph_path = ./data/hannover.graphml
+graph_path = ./data/last_mile_delivery_test.graphml
+
+[Segments]
+import = True
+path = ./data/offline_segments.pkl
+
+[Corridors]
+corridors = 1 2 3 4
+altitude = 250
+delta_z = 25
+speed = 100
+acceleration_length = 50
+file_path_corridors = ./data/usepe-hannover-corridors.geojson
 
 [Strategic_Deconfliction]
 ratio = 3

--- a/usepe/city_model/utils.py
+++ b/usepe/city_model/utils.py
@@ -3,6 +3,7 @@
 """
 Additional functions
 """
+import math
 import string
 
 from osmnx.io import _convert_node_attr_types, _convert_bool_string, _convert_edge_attr_types
@@ -112,6 +113,41 @@ def nearestNode3d( G, lon, lat, altitude ):
             delta_xyz = delta_xyz_aux
             nearest_node = node
     return nearest_node
+
+
+def shortest_dist_to_point( x1, y1, x2, y2, x, y ):
+    '''
+    This function gets the shortest distance from a point (x,y) to a line defined by two points:
+    (x1,y1) and (x2,y2)
+
+    Input:
+        x1 (float): x coordinate
+        y1 (float): y coordinate
+        x2 (float): x coordinate
+        y2 (float): y coordinate
+        x (float): x coordinate
+        y (float): y coordinate
+
+    Output:
+        shortest distance from a point (x,y) to a line
+    '''
+    dx = x2 - x1
+    dy = y2 - y1
+    dr2 = float( dx ** 2 + dy ** 2 )
+
+    lerp = ( ( x - x1 ) * dx + ( y - y1 ) * dy ) / dr2
+    if lerp < 0:
+        lerp = 0
+    elif lerp > 1:
+        lerp = 1
+
+    x0 = lerp * dx + x1
+    y0 = lerp * dy + y1
+
+    _dx = x0 - x
+    _dy = y0 - y
+    square_dist = _dx ** 2 + _dy ** 2
+    return math.sqrt( square_dist )
 
 
 if __name__ == '__main__':

--- a/usepe/use_case/settings_last_mile_delivery_test.cfg
+++ b/usepe/use_case/settings_last_mile_delivery_test.cfg
@@ -24,8 +24,9 @@ directory_hannover = C:\Users\jbueno\Desktop\Stadtmodell_Hannover_CityGML_LoD1\L
 
 [Options]
 one_way = False
-simplify = False
-simplification_distance = 10
+simplify = True
+simplification_distance = 0
+simplification_error = 2
 
 [Outputs]
 graph_path = ./data/last_mile_delivery_test.graphml


### PR DESCRIPTION
Improve the graph simplification. If a node is connected to only two nodes and the three of them are almost contained in a straight line, the node is removed from the graph. 

Approach:
1. For each node X with only two neighbors, we compute the distance from this node X to the straight line defined by the two neighbors.
2. If the distance is less than a permissible error, the node X is removed and the two neighbors are connected.

This helps to greatly reduce the computational effort.

Now, there is a new parameter in the section "Options" of the configuration file:
- "simplification_error": float indicating the maximum distance allowed when removing a node. As default value, we recommend 2 meters.

multi_di_graph_3D.py: new version of the method "simplifyGraph
utils.py: new function to compute the distance between a point and a line "shortest_dist_to_point"
settings.cfg: new parameter of the config file in the "Options" section: "simplification_error"