### PR TITLE
D2C2 Plugin commands

### DIFF
--- a/plugins/usepe_plugin.py
+++ b/plugins/usepe_plugin.py
@@ -19,6 +19,7 @@ __author__ = 'jbueno'
 __copyright__ = '(c) Nommon 2022'
 
 
+active = False
 usepeconfig = None
 usepegraph = None
 usepesegments = None
@@ -31,46 +32,6 @@ usepedronecommands = None
 # ## function, as it is the way BlueSky recognises this file as a plugin.
 def init_plugin():
     ''' Plugin initialisation function. '''
-    # Instantiate the UsepeLogger entity
-    global usepeconfig
-
-    global usepegraph
-    global usepesegments
-    global usepeflightplans
-    global usepestrategic
-    global usepedronecommands
-
-    # ---------------------------------- DEFINED BY USER ------------------------------------
-    config_path = r"C:\workspace3\scenarios-USEPE\scenario\USEPE\exercise_1\settings_exercise_1_reference.cfg"
-    # ------------------------------------------------------------------------------------------
-
-    # graph_path = r"C:\workspace3\scenarios-USEPE\scenario\USEPE\exercise_1\data\testing_graph.graphml"
-    # segment_path = r"C:\workspace3\scenarios-USEPE\scenario\USEPE\exercise_1\data\offline_segments.pkl"
-    # flight_plan_csv_path = r"C:\workspace3\scenarios-USEPE\scenario\USEPE\exercise_1\data\delivery_testing.csv"
-    #
-    # initial_time = 0  # seconds
-    # final_time = 7200  # seconds
-
-    usepeconfig = configparser.ConfigParser()
-    usepeconfig.read( config_path )
-
-    graph_path = usepeconfig['BlueSky']['graph_path']
-    segment_path = usepeconfig['BlueSky']['segment_path']
-    flight_plan_csv_path = usepeconfig['BlueSky']['flight_plan_csv_path']
-
-    initial_time = int( usepeconfig['BlueSky']['initial_time'] )
-    final_time = int( usepeconfig['BlueSky']['final_time'] )
-
-    usepegraph = UsepeGraph( graph_path )
-    usepesegments = UsepeSegments( segment_path )
-    usepestrategic = UsepeStrategicDeconfliction( initial_time, final_time )
-    usepeflightplans = UsepeFlightPlan( flight_plan_csv_path )
-    usepedronecommands = UsepeDroneCommands()
-
-    # Activate the detection and resolution method, and logger
-    configuration_path = r".{}".format( usepeconfig['BlueSky']['configuration_path'] )
-    stack.stack( 'PCALL {} REL'.format( configuration_path ) )
-    stack.stack( 'OP' )
 
     # Configuration parameters
     config = {
@@ -86,40 +47,108 @@ def init_plugin():
 
         # Reset
         'reset': reset }
+    
+    stackfunctions = {
+        'USEPE': [
+            'USEPE CONFIG/ON/OFF, [config_path]',
+            'txt, [txt]',
+            usepe,
+            'Set path to configuration file, or turn on/off the plugin.'
+        ]
+    }
 
     # init_plugin() should always return a configuration dict.
-    return config
+    return config, stackfunctions
 
 
 def update():
-    if sim.simt > usepeconfig.getint( 'BlueSky', 'final_time' ):
-        stack.stack( 'RESET' )
-        stack.stack( 'QUIT' )
+    if active:
+        if sim.simt > usepeconfig.getint( 'BlueSky', 'final_time' ):
+            stack.stack( 'RESET' )
+            stack.stack( 'QUIT' )
 
-    usepegraph.update()
-    usepesegments.update()
-    usepestrategic.update()
-    usepeflightplans.update()
-    usepedronecommands.update()
+        usepegraph.update()
+        usepesegments.update()
+        usepestrategic.update()
+        usepeflightplans.update()
+        usepedronecommands.update()
     return
 
 
 def preupdate():
-    usepegraph.preupdate()
-    usepesegments.preupdate()
-    usepestrategic.preupdate()
-    usepeflightplans.preupdate()
-    usepedronecommands.preupdate()
+    if active:
+        usepegraph.preupdate()
+        usepesegments.preupdate()
+        usepestrategic.preupdate()
+        usepeflightplans.preupdate()
+        usepedronecommands.preupdate()
     return
 
 
 def reset():
-    usepegraph.reset()
-    usepesegments.reset()
-    usepestrategic.reset()
-    usepeflightplans.reset()
-    usepedronecommands.reset()
+    if active:
+        usepegraph.reset()
+        usepesegments.reset()
+        usepestrategic.reset()
+        usepeflightplans.reset()
+        usepedronecommands.reset()
     return
+
+
+def usepe(cmd, args=''):
+    ''' USEPE command for the plugin
+        Options:
+        CONFIG: Set the configuration file, and initialise the various parts of the plugin.
+        ON: Activate the plugin.
+        OFF: Deactivate the plugin.
+    '''
+
+    global active
+    global usepeconfig
+
+    global usepegraph
+    global usepesegments
+    global usepeflightplans
+    global usepestrategic
+    global usepedronecommands
+
+    if cmd == 'CONFIG':
+        if args == '':
+            return False, f'"USEPE CONFIG" needs a valid path to configuration file.'
+
+        config_path = args
+        usepeconfig = configparser.ConfigParser()
+        usepeconfig.read(config_path)
+
+        graph_path = usepeconfig['BlueSky']['graph_path']
+        segment_path = usepeconfig['BlueSky']['segment_path']
+        flight_plan_csv_path = usepeconfig['BlueSky']['flight_plan_csv_path']
+
+        initial_time = int(usepeconfig['BlueSky']['initial_time'])
+        final_time = int(usepeconfig['BlueSky']['final_time'])
+
+        usepegraph = UsepeGraph(graph_path)
+        usepesegments = UsepeSegments(segment_path)
+        usepestrategic = UsepeStrategicDeconfliction(initial_time, final_time)
+        usepeflightplans = UsepeFlightPlan(flight_plan_csv_path)
+        usepedronecommands = UsepeDroneCommands()
+
+
+        return True, f'The configuration file has been set.'
+
+    elif cmd == 'ON':
+        if usepeconfig is not None:
+            active = True
+            return True, f'USEPE Plugin is now active'
+        else:
+            return False, f'The configuration file is not provided. First use "USEPE CONFIG config_path"'
+
+    elif cmd == 'OFF':
+        active = False
+        return True, f'USEPE Plugin is now inactive'
+
+    else:
+        return False, f'Available commands are: CONFIG, ON, OFF'
 
 
 class UsepeGraph( core.Entity ):


### PR DESCRIPTION
With this change the configuration file path is set via a console command, rather than a static definition within the plugin file.
This should make it more user friendly to use D2C2, and can be done via a setup `.scn` file.

Changes:
- Command syntax: `USEPE CONFIG/ON/OFF, [config_path]`
  - `CONFIG config_path`: Sets configuration file path, and initialises the various parts of the plugin
  - `ON`: Activates the plugin
  - `OFF`: Deactivates the plugin
- Moved code to initialise the classes from `init_plugin()` to the new `usepe()` (which handles the commands)
- Removed `plugins/__init__.py` (which I assume was automatically added by an IDE) as the plugin functionality is already handled by BlueSky

The plugin should now be loaded in the same `.scn` file where other plugins are loaded, followed by the `CONFIG` and `ON` commands.

If anything is unclear, don't hesitate to ask.